### PR TITLE
fix: delete queues

### DIFF
--- a/Server/manual_tests/fake_car.py
+++ b/Server/manual_tests/fake_car.py
@@ -21,7 +21,7 @@ async def send_messages(websocket, car_id):
     while True:
         msg = generate_telemetry(car_id)
         await websocket.send(msg)
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.0001)
 
 async def main():
     car_id = "fake_car"

--- a/Server/manual_tests/fake_client.py
+++ b/Server/manual_tests/fake_client.py
@@ -19,7 +19,7 @@ async def send_messages(websocket, object_id):
     while True:
         msg = generate_signal()
         await websocket.send(msg)
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.0001)
 
 async def main():
     client_id = "fake_client"

--- a/Server/src/__main__.py
+++ b/Server/src/__main__.py
@@ -2,11 +2,11 @@ import asyncio
 from contextlib import asynccontextmanager
 import logging
 from pathlib import Path
-from typing import Callable, Coroutine
+from typing import Callable
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 import uvicorn
-from src.managers import WebsocketManager, CarPoolManager, TransferManager
+from src.managers import WebsocketManager, CarPoolManager
 from src.contracts import CarSignal, CarTelemetry, ClientSignal, ClientTelemetry, repack
 
 logger = logging.getLogger(__name__)
@@ -14,12 +14,6 @@ html = Path("src/client.html").read_text()
 car_manager = WebsocketManager()
 client_manager = WebsocketManager()
 car_pool_manager = CarPoolManager()
-transfer_manager = TransferManager(
-    car_manager=car_manager, 
-    client_manager=client_manager,
-    signals_sleep=0.000001,
-    telemetry_sleeps=0.000001
-)
 background_tasks = set()
 SLEEP_UPDATE_CARS_TIME = 1.0
 
@@ -29,14 +23,6 @@ async def update_cars_loop() -> None:
         car_pool_manager.update_available_cars(all_cars_ids)
         await asyncio.sleep(SLEEP_UPDATE_CARS_TIME)
 
-async def handle_signals_loop() -> None:
-    while True:
-        await transfer_manager.handle_signals()
-
-async def handle_telemetry_loop() -> None:
-    while True:
-        await transfer_manager.handle_telemetry()
-
 def add_loop_task(func: Callable) -> None:
     task = asyncio.create_task(func())
     background_tasks.add(task)
@@ -45,8 +31,6 @@ def add_loop_task(func: Callable) -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     add_loop_task(update_cars_loop)
-    add_loop_task(handle_signals_loop)
-    add_loop_task(handle_telemetry_loop)
     yield
 
 
@@ -67,7 +51,7 @@ async def websocket_endpoint(websocket: WebSocket, car_id: str):
             if not (client_id := car_pool_manager.car_owner_pool.get(car_id)):
                 continue
             client_telemetry = repack(telemetry, ClientTelemetry)
-            await transfer_manager.add_telemetry(client_telemetry, client_id)
+            await client_manager.send(client_id, client_telemetry)
     except WebSocketDisconnect:
         car_manager.disconnect(car_id)
 
@@ -82,7 +66,7 @@ async def websocket_endpoint(websocket: WebSocket, client_id: str, car_id):
             if not (_car_id := car_pool_manager.owner_car_pool.get(client_id)):
                 continue
             car_signal = repack(client_signal, CarSignal)
-            await transfer_manager.add_signal(car_signal, _car_id)
+            await car_manager.send(car_id, car_signal)
     except WebSocketDisconnect:
         client_manager.disconnect(client_id)
         car_pool_manager.release_car(car_id, client_id)


### PR DESCRIPTION
- Удален transfer-manager вместе с очередями. Он вызывал утечки памяти предположительно из-за замедления передачи информации от тачек клиенту
- Теперь передача данных вызываетсся на уровне вебсокета
- Уменьшена задержка на отправку в ручных тестах